### PR TITLE
Update Travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,35 @@
 language: cpp
-sudo: false
 
-env:
-  global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
+addons:
+  apt_packages:
+    - libgmp-dev
+    - libreadline-dev
+    - zlib1g-dev
+
+matrix:
+  include:
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
+    - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=master ABI=32
+      addons:
+        apt_packages:
+          - libgmp-dev:i386
+          - libreadline-dev:i386
+          - zlib1g-dev:i386
+          - gcc-multilib
+          - g++-multilib
 
 branches:
   except:
     - gh-pages
 
-matrix:
-  include:
-    - env: GAPBRANCH="stable-4.9"
-#    Clang linking broken with libtool/ubuntu 14.04
-#    - env: CC=clang CXX=clang++
-#      compiler: clang
-    - env:
-      compiler: gcc
-    - env: GAP_CONFIGFLAGS="--enable-checking"
-      compiler: gcc
-    - env: ABI=32
-      addons:
-        apt_packages:
-          - libgmp-dev:i386
-          - libreadline-dev:i386
-          - gcc-multilib
-          - g++-multilib
-
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
-  - bash scripts/gather-coverage.sh
+  - scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This tests against GAP 4.9, 4.10, 4.11 and adds various build dependencies.

I also dropped the test with `GAP_CONFIGFLAGS="--enable-checking"` because as far as I can tell, GAP's configure does not handle this configure argument. But perhaps I am misunderstanding something here?