### PR TITLE
Output record components in a sorted order

### DIFF
--- a/gap/json.gi
+++ b/gap/json.gi
@@ -80,15 +80,15 @@ function(o, r)
   local i, first;
   first := true;
   PrintTo(o, "{");
-  for i in RecNames(r) do
+  for i in Set(RecNames(r)) do # sort for output stability across GAP sessions
     if first then
       first := false;
     else
       PrintTo(o, ",");
     fi;
-    _GapToJsonStreamInternal(o, i);
+    _GapToJsonStreamInternal(o, i); # a string or small integer
     PrintTo(o, " : ");
-    _GapToJsonStreamInternal(o, r.(i));
+    _GapToJsonStreamInternal(o, r.(i)); # an arbitrary GAP object
   od;
   PrintTo(o, "}");
 end );

--- a/tst/test_record.tst
+++ b/tst/test_record.tst
@@ -1,0 +1,11 @@
+gap> START_TEST("json package: test_record.tst");
+gap> LoadPackage("json", false);;
+
+#
+gap> r := rec(second := rec(two := 3, one := 4), first := true);;
+gap> r.5 := [1, 2, 3];;
+gap> GapToJsonString(r);
+"{\"5\" : [1,2,3],\"first\" : true,\"second\" : {\"one\" : 4,\"two\" : 3}}"
+
+#
+gap> STOP_TEST("json package: test_record.tst");


### PR DESCRIPTION
The ordering given by `RecNames` is not necessarily consistent between GAP versions, and it doesn't seem to be predictable, e.g.:
```
gap> RecNames(rec(a := 3, b := 2));
[ "b", "a" ]
```
For me it would be nice if there was more stability and predictability with the JSON output of a GAP record (although it's by no means essential).

In particular, this would be nice for the `help-links.json` file that I introduce in GAP PR https://github.com/gap-system/gap/pull/4572 – we will produce one such file per GAP release, for use on the GAP website. The same applies for the `package-infos.json` file. It would be nice if the diffs of these files across different GAP versions reflected actual changes, rather than just random reorderings because of GAP.