### PR TITLE
Add LoadKernelExtension

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -76,7 +76,7 @@ Dependencies := rec(
 ),
 
 AvailabilityTest := function()
-   if Filename(DirectoriesPackagePrograms("json"), "json.so") = fail then
+   if IsKernelExtensionAvailable("json") = false then
      LogPackageLoadingMessage( PACKAGE_WARNING,
              [ "kernel functions for json are not available." ] );
      return false;

--- a/init.g
+++ b/init.g
@@ -3,10 +3,9 @@
 #
 # Reading the declaration part of the package.
 #
-_PATH_SO:=Filename(DirectoriesPackagePrograms("json"), "json.so");
-if _PATH_SO <> fail then
-    LoadDynamicModule(_PATH_SO);
+
+if LoadKernelExtension("json", "json") = false then
+    Error("failed to load json kernel extension");
 fi;
-Unbind(_PATH_SO);
 
 ReadPackage( "json", "gap/json.gd");


### PR DESCRIPTION
Solves https://github.com/gap-system/gap/issues/5761.

The build failed because of `codecov`; everyone around agrees to ignore testing such thing.